### PR TITLE
Add pyproject with uv deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "thoughtfull"
+version = "0.1.0"
+description = "A tool for collecting slack threads, personal notes, and other data together so that it can easily be searched."
+requires-python = ">=3.11"
+dependencies = [
+    "pydantic",
+    "loguru",
+    "tenacity",
+]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[build-system]
+requires = ["uv>=0.7"]
+build-backend = "uv.build"


### PR DESCRIPTION
## Summary
- add basic `pyproject.toml` using uv

Attempted to create a uv virtual environment and install pytest, pydantic, loguru, and tenacity, but the network was unavailable.

## Testing
- `uv venv .venv`
- `uv pip install pytest pydantic loguru tenacity` *(fails: No route to host)*